### PR TITLE
feat: support aarch64 and modern NVIDIA Blackwell (sm_100) architectures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,17 @@ if '--cuda' in sys.argv:
 if build_cuda or 'build_ext' in sys.argv:
     try:
         from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+        import torch
+        if torch.cuda.is_available():
+            major, minor = torch.cuda.get_device_capability()
+            # If we detect Blackwell (12.x), force "+ PTX" for compatibility
+            if major >= 12:
+                arch_list = f"{major}.{minor}+PTX"
+            else:
+                arch_list = f"{major}.{minor}"
+            print(f"Auto-detected GPU architecture: {arch_list}")
+            # Force-set the architecture environment variable so PyTorch sees it
+            os.environ['TORCH_CUDA_ARCH_LIST'] = arch_list
 
         def nvcc_flags():
             nvcc_threads = os.getenv("NVCC_THREADS", "8")

--- a/turboquant/cuda_backend.py
+++ b/turboquant/cuda_backend.py
@@ -10,6 +10,7 @@ Falls back to pure PyTorch if kernels are not available.
 
 import math
 import os
+import glob
 import torch
 import torch.nn as nn
 from typing import Optional, Tuple
@@ -21,7 +22,9 @@ try:
     _kernel_dir = os.path.dirname(os.path.abspath(__file__))
     import importlib.util
     for mod_name in ['cuda_qjl_quant', 'cuda_qjl_score', 'cuda_qjl_gqa_score', 'quantization']:
-        so_path = os.path.join(_kernel_dir, f'{mod_name}.cpython-312-x86_64-linux-gnu.so')
+        # Search for any .so file that starts with the module name. (adds support for non-x86)
+        so_files = glob.glob(os.path.join(_kernel_dir, f'{mod_name}.*.so'))
+        so_path = so_files[0] if so_files else ""
         if os.path.exists(so_path):
             spec = importlib.util.spec_from_file_location(mod_name, so_path)
             mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
Title: Support non-x86 architectures (aarch64) and modern NVIDIA GPUs (Blackwell/sm_100)

Description: This PR enables rotorquant to be built and run on NVIDIA Grace Blackwell (GB10) systems and other ARM64 (aarch64) environments.

Key Improvements:
Robust Build System: Updated setup.py to auto-detect the CUDA environment, properly set architecture lists (dynamically adding +PTX for compatibility).

Cross-Platform Compatibility: Replaced hardcoded .so extension references in cuda_backend.py with dynamic glob matching, allowing the library to load compiled extensions on any platform (e.g., aarch64).

Future-Proofing: Added support for NVIDIA Blackwell (sm_100) via PTX fallback, ensuring the kernels are JIT-compatible with modern NVIDIA driver architectures.

Testing:
Verified on NVIDIA DGX Spark (Grace Blackwell GB10, Ubuntu aarch64). The build process is now self-contained, and the end-to-end benchmark suite passes successfully.