### PR TITLE
Fix sign bugs in Cl(3,0) geometric_product breaking associativity

### DIFF
--- a/tests/test_clifford.py
+++ b/tests/test_clifford.py
@@ -41,10 +41,15 @@ class TestGeometricProduct:
         r = geometric_product(e2, e1)
         assert torch.allclose(r[4], torch.tensor(-1.0), atol=1e-6)
 
-    @pytest.mark.xfail(reason="Full GP table has a sign error in some terms; "
-                       "RotorQuant uses the sparse GP path which is correct")
     def test_associativity(self):
-        """(a * b) * c == a * (b * c)."""
+        """(a * b) * c == a * (b * c).
+
+        Associativity is a foundational axiom of any Clifford / geometric
+        algebra. Prior revisions of this file carried sign errors in
+        r1/r2/r3/r12/r13/r23/r123 that caused this test to fail and was
+        previously marked xfail; the fix derives the Cayley table from
+        scratch via bubble-sort sign tracking and restores associativity.
+        """
         torch.manual_seed(42)
         a = torch.randn(8)
         b = torch.randn(8)
@@ -52,6 +57,108 @@ class TestGeometricProduct:
         lhs = geometric_product(geometric_product(a, b), c)
         rhs = geometric_product(a, geometric_product(b, c))
         assert torch.allclose(lhs, rhs, atol=1e-5)
+
+    def test_associativity_batch(self):
+        """Associativity across a batch of random multivectors."""
+        torch.manual_seed(7)
+        a = torch.randn(16, 8)
+        b = torch.randn(16, 8)
+        c = torch.randn(16, 8)
+        lhs = geometric_product(geometric_product(a, b), c)
+        rhs = geometric_product(a, geometric_product(b, c))
+        assert torch.allclose(lhs, rhs, atol=1e-5)
+
+    def test_scalar_identity_left(self):
+        """1 * x == x for arbitrary multivector x."""
+        torch.manual_seed(42)
+        one = torch.tensor([1.0, 0, 0, 0, 0, 0, 0, 0])
+        x = torch.randn(8)
+        assert torch.allclose(geometric_product(one, x), x, atol=1e-6)
+
+    def test_scalar_identity_right(self):
+        """x * 1 == x for arbitrary multivector x."""
+        torch.manual_seed(42)
+        one = torch.tensor([1.0, 0, 0, 0, 0, 0, 0, 0])
+        x = torch.randn(8)
+        assert torch.allclose(geometric_product(x, one), x, atol=1e-6)
+
+    def test_basis_vector_squares(self):
+        """e_i * e_i = +1 for i in {1, 2, 3}; e_ij * e_ij = -1 for grade-2."""
+        def basis(idx):
+            v = torch.zeros(8)
+            v[idx] = 1.0
+            return v
+
+        # Grade-1 squares
+        for i in (1, 2, 3):
+            r = geometric_product(basis(i), basis(i))
+            expected = torch.zeros(8); expected[0] = 1.0
+            assert torch.allclose(r, expected, atol=1e-6), f"e{i}^2 != +1"
+
+        # Grade-2 squares are -1
+        for i in (4, 5, 6):
+            r = geometric_product(basis(i), basis(i))
+            expected = torch.zeros(8); expected[0] = -1.0
+            assert torch.allclose(r, expected, atol=1e-6), f"e_{i}^2 != -1"
+
+        # Pseudoscalar squares to -1
+        r = geometric_product(basis(7), basis(7))
+        expected = torch.zeros(8); expected[0] = -1.0
+        assert torch.allclose(r, expected, atol=1e-6), "e123^2 != -1"
+
+    def test_basis_vector_anticommutation(self):
+        """e_i * e_j = -e_j * e_i for i != j in {1,2,3}."""
+        def basis(idx):
+            v = torch.zeros(8)
+            v[idx] = 1.0
+            return v
+
+        for i, j in [(1, 2), (1, 3), (2, 3)]:
+            r_ij = geometric_product(basis(i), basis(j))
+            r_ji = geometric_product(basis(j), basis(i))
+            assert torch.allclose(r_ij, -r_ji, atol=1e-6), (
+                f"e{i}*e{j} != -e{j}*e{i}"
+            )
+
+    def test_e1_e2_e3_chain_associates(self):
+        """(e1 * e2) * e3 == e1 * (e2 * e3) == e123.
+
+        Specific instance of associativity that was broken in the prior
+        Cayley table. (e1*e2) = e12 and e12 * e3 = e123. Separately,
+        (e2*e3) = e23 and e1 * e23 = e123. Both routes must agree.
+        """
+        e1 = torch.tensor([0, 1.0, 0, 0, 0, 0, 0, 0])
+        e2 = torch.tensor([0, 0, 1.0, 0, 0, 0, 0, 0])
+        e3 = torch.tensor([0, 0, 0, 1.0, 0, 0, 0, 0])
+
+        left = geometric_product(geometric_product(e1, e2), e3)
+        right = geometric_product(e1, geometric_product(e2, e3))
+
+        expected = torch.zeros(8); expected[7] = 1.0  # e123
+        assert torch.allclose(left, expected, atol=1e-6)
+        assert torch.allclose(right, expected, atol=1e-6)
+        assert torch.allclose(left, right, atol=1e-6)
+
+    def test_e23_times_e123(self):
+        """e23 * e123 = -e1.
+
+        Derivation: (e2 e3)(e1 e2 e3); move e1 leftward past e2 and e3
+        with two sign flips: e2 e3 e1 e2 e3 = e1 e2 e3 e2 e3 = -e1 after
+        collapsing e_i^2 -> +1. This was wrong in the prior Cayley table.
+        """
+        e23 = torch.tensor([0, 0, 0, 0, 0, 0, 1.0, 0])
+        e123 = torch.tensor([0, 0, 0, 0, 0, 0, 0, 1.0])
+        r = geometric_product(e23, e123)
+        expected = torch.tensor([0, -1.0, 0, 0, 0, 0, 0, 0])
+        assert torch.allclose(r, expected, atol=1e-6)
+
+    def test_e12_times_e3(self):
+        """e12 * e3 = e123."""
+        e12 = torch.tensor([0, 0, 0, 0, 1.0, 0, 0, 0])
+        e3 = torch.tensor([0, 0, 0, 1.0, 0, 0, 0, 0])
+        r = geometric_product(e12, e3)
+        expected = torch.zeros(8); expected[7] = 1.0
+        assert torch.allclose(r, expected, atol=1e-6)
 
     def test_batch_dimensions(self):
         """GP should work with batch dims."""

--- a/turboquant/clifford.py
+++ b/turboquant/clifford.py
@@ -30,34 +30,50 @@ def geometric_product(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     Multiplication table for Cl(3,0) with signature (+,+,+):
         e_i * e_i = +1  for i in {1,2,3}
         e_i * e_j = -e_j * e_i  for i != j
+
+    Basis ordering: [s, e1, e2, e3, e12, e13, e23, e123] where
+    e12 = e1 e2, e13 = e1 e3, e23 = e2 e3, e123 = e1 e2 e3.
+
+    The Cayley table below was derived from scratch via bubble-sort sign
+    tracking of basis-vector concatenations, collapsing e_i^2 = +1.
+    Each term is the sign of moving the right operand's basis vectors
+    past the left operand's basis vectors into canonical order. Spot
+    check: e23 * e123 = (e2 e3)(e1 e2 e3); moving e1 leftward past
+    e2 e3 picks up two sign flips, leaving e1 e2 e3 e2 e3 = -e1 after
+    collapsing e_i^2 -> +1, so the (a23, b123) coefficient on r1 must
+    be -1 (not +1 as in earlier revisions of this file).
+
+    Verified by (a*b)*c == a*(b*c) on random multivectors; see
+    tests/test_clifford.py::TestGeometricProduct::test_associativity.
     """
     # Unbind components
     a0, a1, a2, a3, a12, a13, a23, a123 = a.unbind(dim=-1)
     b0, b1, b2, b3, b12, b13, b23, b123 = b.unbind(dim=-1)
 
-    # Grade 0 (scalar)
+    # Grade 0 (scalar). e123 squares to -1 in Cl(3,0):
+    # e123^2 = (e1 e2 e3)(e1 e2 e3) = -e1 e1 e2 e2 e3 e3 = -1.
     r0 = (a0*b0 + a1*b1 + a2*b2 + a3*b3
            - a12*b12 - a13*b13 - a23*b23 - a123*b123)
 
     # Grade 1 (vectors)
     r1 = (a0*b1 + a1*b0 - a2*b12 + a12*b2 - a3*b13 + a13*b3
-           + a23*b123 + a123*b23)
+           - a23*b123 - a123*b23)
     r2 = (a0*b2 + a2*b0 + a1*b12 - a12*b1 - a3*b23 + a23*b3
-           - a13*b123 - a123*b13)
+           + a13*b123 + a123*b13)
     r3 = (a0*b3 + a3*b0 + a1*b13 - a13*b1 + a2*b23 - a23*b2
-           + a12*b123 + a123*b12)
+           - a12*b123 - a123*b12)
 
     # Grade 2 (bivectors)
-    r12 = (a0*b12 + a12*b0 + a1*b2 - a2*b1 + a13*b23 - a23*b13
-            + a3*b123 - a123*b3)
-    r13 = (a0*b13 + a13*b0 + a1*b3 - a3*b1 - a12*b23 + a23*b12
-            - a2*b123 + a123*b2)
-    r23 = (a0*b23 + a23*b0 + a2*b3 - a3*b2 + a12*b13 - a13*b12
-            + a1*b123 - a123*b1)
+    r12 = (a0*b12 + a12*b0 + a1*b2 - a2*b1 - a13*b23 + a23*b13
+            + a3*b123 + a123*b3)
+    r13 = (a0*b13 + a13*b0 + a1*b3 - a3*b1 + a12*b23 - a23*b12
+            - a2*b123 - a123*b2)
+    r23 = (a0*b23 + a23*b0 + a2*b3 - a3*b2 - a12*b13 + a13*b12
+            + a1*b123 + a123*b1)
 
     # Grade 3 (pseudoscalar)
-    r123 = (a0*b123 + a123*b0 + a1*b23 - a23*b1 - a2*b13 + a13*b2
-             + a3*b12 - a12*b3)
+    r123 = (a0*b123 + a123*b0 + a1*b23 + a23*b1 - a2*b13 - a13*b2
+             + a3*b12 + a12*b3)
 
     return torch.stack([r0, r1, r2, r3, r12, r13, r23, r123], dim=-1)
 


### PR DESCRIPTION
## Summary

`turboquant/clifford.py::geometric_product` had sign errors in `r1`, `r2`, `r3`, `r12`, `r13`, `r23`, and `r123`. The full geometric product failed `(a * b) * c == a * (b * c)` — a foundational axiom of any Clifford / geometric algebra — and produced wrong basis-vector products (e.g. `e23 * e123` returned `+e1` instead of `-e1`; `e12 * e3` returned `-e123` instead of `+e123`).

The existing `tests/test_clifford.py::TestGeometricProduct::test_associativity` was already marked `@pytest.mark.xfail` with the note "Full GP table has a sign error in some terms; RotorQuant uses the sparse GP path which is correct" — so the bug was known but not yet repaired. This PR repairs it.

## Repro on `main` (before the fix)

```python
import torch
from turboquant.clifford import geometric_product

# e23 * e123 should be -e1 in Cl(3,0)
e23  = torch.tensor([0, 0, 0, 0, 0, 0, 1.0, 0])
e123 = torch.tensor([0, 0, 0, 0, 0, 0, 0, 1.0])
r = geometric_product(e23, e123)
print(r)  # main: [0, +1, 0, ...] ; fix: [0, -1, 0, ...]

# Associativity on random multivectors
torch.manual_seed(42)
a, b, c = torch.randn(8), torch.randn(8), torch.randn(8)
lhs = geometric_product(geometric_product(a, b), c)
rhs = geometric_product(a, geometric_product(b, c))
print(torch.allclose(lhs, rhs, atol=1e-5))  # main: False ; fix: True
```

## Fix derivation

The corrected Cayley table was derived from scratch via bubble-sort sign tracking of basis-vector concatenations, collapsing `e_i^2 = +1`. The derivation is pinned into the module docstring with a worked example for the `e23 * e123` entry.

Spot check (rewritten in the docstring): `e23 * e123 = (e2 e3)(e1 e2 e3)`. Move `e1` leftward past `e2` and `e3`, picking up two sign flips: `e2 e3 e1 e2 e3 -> e1 e2 e3 e2 e3 -> -e1` after collapsing `e_i^2 -> +1`. Therefore the coefficient on `a23 * b123` in `r1` must be `-1`, not `+1` as in the prior table.

The new docstring carries the basis ordering convention `[s, e1, e2, e3, e12, e13, e23, e123]` with `e12 = e1 e2`, `e13 = e1 e3`, `e23 = e2 e3`, `e123 = e1 e2 e3` so the table can be re-derived by inspection.

## Test plan

- [x] **Existing `test_associativity`**: previously `@xfail`, now strict — `(a*b)*c == a*(b*c)` on random multivectors **PASSES**.
- [x] **New `test_associativity_batch`**: associativity over a batch of 16 random multivectors **PASSES**.
- [x] **New `test_e1_e2_e3_chain_associates`**: `(e1 * e2) * e3 == e1 * (e2 * e3) == e123` **PASSES** (was wrong direction on `main`).
- [x] **New `test_e23_times_e123`**: direct regression test for the table entry called out in the derivation, asserts `= -e1` **PASSES**.
- [x] **New `test_e12_times_e3`**: asserts `= e123` **PASSES** (was `-e123` on `main`).
- [x] **New `test_scalar_identity_left` / `test_scalar_identity_right`**: `1 * x == x == x * 1` **PASSES** (already correct on `main`, included as a basic GP contract check).
- [x] **New `test_basis_vector_squares`**: `e_i^2 = +1` for grade-1, `-1` for grade-2 / pseudoscalar **PASSES**.
- [x] **New `test_basis_vector_anticommutation`**: `e_i e_j = -e_j e_i` for `i != j` **PASSES**.
- [x] **No regressions**: full `tests/test_clifford.py` + `test_rotorquant.py` + `test_turboquant.py` + `test_lloyd_max.py` = **94 passed** on the fix branch.

The rotor-sandwich, norm-preservation, and embed/extract paths in `test_rotorquant.py` were already passing pre-fix because they don't exercise the broken `(a23, b123)` / `(a13, b123)` / `(a12, b123)` table entries — those require both operands to carry non-zero grade-2 AND grade-3 components, which the sparse RotorQuant path never produces. The fix doesn't break them.

## Discovery context

Found during RALL-260 Phase G (3D Clifford-rotor KV-cache quantization) in the [RationAll](https://github.com/research-developer/RationAll) project. RALL-260 PR #465 vendored a corrected implementation under leading-underscore names (`_geometric_product`, `_reverse`, `_rotor_sandwich` in `rationall/kv_quant_clifford.py`) rather than depend on the broken upstream. Upstreaming the fix here lets downstream consumers drop the vendor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)